### PR TITLE
Add user_defined_shear tags for Reduced DLB

### DIFF
--- a/hawc2_wrapper/hawc2_aeroelasticsolver.py
+++ b/hawc2_wrapper/hawc2_aeroelasticsolver.py
@@ -141,6 +141,12 @@ class HAWC2Workflow(Component):
             pass
 
         shutil.copytree('control', workdir+'/control')
+        
+        try:
+            shutil.copytree('data/shear', workdir+'/data/shear')
+        except:
+            pass
+        
         os.chdir(workdir)
 
         vt = self.writer.vartrees

--- a/hawc2_wrapper/hawc2_inputreader.py
+++ b/hawc2_wrapper/hawc2_inputreader.py
@@ -172,6 +172,11 @@ class HAWC2InputReader(object):
             else:
                 for rm in ramp:
                     vt.wind_ramp_abs.append(rm)
+                    
+        ud_shear = section.get_entry('user_defined_shear')
+        if ud_shear is not None:
+            vt.user_defined_shear = True
+            vt.shear_file = ud_shear[0]
 
         gust = section.get_entry('iec_gust')
         if gust is not None:

--- a/hawc2_wrapper/hawc2_inputwriter.py
+++ b/hawc2_wrapper/hawc2_inputwriter.py
@@ -233,6 +233,8 @@ class HAWC2InputWriter(object):
             wind.append('wind_ramp_factor' + 4*fmt %
                         (wind_vt.wind_ramp_t0, wind_vt.wind_ramp_t1,
                          wind_vt.wind_ramp_factor0, wind_vt.wind_ramp_factor1))
+        if wind_vt.user_defined_shear:
+            wind.append('user_defined_shear %s' % wind_vt.shear_file)
 
         if wind_vt.iec_gust:
             wind.append('iec_gust %s' % wind_vt.iec_gust_type + 4*fmt %
@@ -608,6 +610,7 @@ class HAWC2InputWriter(object):
         for i in range(len(self.vartrees.output.sensor_list)):
             sns.append('  ' + self.vartrees.output.sensor_list[i])
         sns.append('end output')
+        sns.append('exit')
 
         sns = [s+';' for s in sns]
 

--- a/hawc2_wrapper/hawc2_vartrees.py
+++ b/hawc2_wrapper/hawc2_vartrees.py
@@ -431,6 +431,8 @@ class HAWC2Wind(object):
         # 0=None,1=constant,2=logarithmic,3=power law,4=linear
         self.shear_type = 1
         self.shear_factor = 0.  # Shear parameter - depends on the shear type
+        self.user_defined_shear = False
+        self.shear_file = './data/shear/0000.dat'
         self.turb_format = 0    # Turbulence format (0=none, 1=mann, 2=flex)
         # Tower shadow model 0=none, 1=potential, 2=jet model, 3=potential_2
         self.tower_shadow_method = 0
@@ -449,9 +451,9 @@ class HAWC2Wind(object):
         self.var = ['density', 'wsp', 'tint', 'horizontal_input', 'shear_type',
                     'shear_factor', 'turb_format', 'tower_shadow_method',
                     'scale_time_start', 'wind_ramp_t0', 'wind_ramp_t1',
-                    'wind_ramp_factor0', 'wind_ramp_factor1', 'iec_gust',
-                    'iec_gust_type', 'G_A', 'G_phi0', 'G_t0', 'G_T',
-                    'wind_ramp_abs']
+                    'wind_ramp_factor0', 'wind_ramp_factor1', 'user_defined_shear',
+                    'shear_file', 'iec_gust', 'iec_gust_type', 'G_A', 'G_phi0',
+                    'G_t0', 'G_T', 'wind_ramp_abs']
 
     def add_shadow(self, shadow_name):
 


### PR DESCRIPTION
- user can add user_defined_shear command to htc files;
- to use the user_defined_shear, the user has to provide a .dat file, which specifics are described in the H2 manual;
- the wrapper will copy the shear files to each new H2 directory; the files has to be placed in data/shear/