### PR TITLE
Added possibility to consider safety factor in blade load envelopes

### DIFF
--- a/hawc2_wrapper/hawc2_aeroelasticsolver.py
+++ b/hawc2_wrapper/hawc2_aeroelasticsolver.py
@@ -482,7 +482,30 @@ class HAWC2AeroElasticSolver(Group):
                 config['HAWC2Outputs']['nr_blades_out'] = 1
                 print 'No number of blades defined for output analysis, proceeding ' +\
                       'with one blade output analysis.'
-        if 'psf' not in config['HAWC2Outputs'].keys():
+        if 'psf' in config['HAWC2Outputs'].keys():
+            if config['HAWC2Outputs']['psf'] == {}:
+            print 'Partial safety factors dictionary called, but not initialized...' +\
+                  'proceeding with standard IEC values and DLC labels...'
+                config['HAWC2Outputs']['psf']['dlc12'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc13'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc14'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc15'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc21'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc22'] = 1.1
+                config['HAWC2Outputs']['psf']['dlc23'] = 1.1
+                config['HAWC2Outputs']['psf']['dlc24'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc31'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc32'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc33'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc41'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc42'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc51'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc61'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc62'] = 1.1
+                config['HAWC2Outputs']['psf']['dlc63'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc64'] = 1.35
+                config['HAWC2Outputs']['psf']['dlc81'] = 1.5
+        else:
             print 'No safety factors for load analysis considered...'
         if 'data_directory' not in config['HAWC2InputWriter'].keys():
             config['HAWC2InputWriter']['data_directory'] = 'data'

--- a/hawc2_wrapper/hawc2_aeroelasticsolver.py
+++ b/hawc2_wrapper/hawc2_aeroelasticsolver.py
@@ -476,12 +476,14 @@ class HAWC2AeroElasticSolver(Group):
                 config['HAWC2Outputs']['Nx'] = 36
             if 'Nsectors' not in config['HAWC2Outputs'].keys():
                 config['HAWC2Outputs']['Nsectors'] = 12
-                print 'No sectors number defined for load envelope, proceeding' +\
+                print 'No sectors number defined for load envelope, proceeding ' +\
                       'with the default value of 12 (30deg sector).'
             if 'nr_blades_out' not in config['HAWC2Outputs'].keys():
                 config['HAWC2Outputs']['nr_blades_out'] = 1
-                print 'No number of blades defined for output analysis, proceeding' +\
+                print 'No number of blades defined for output analysis, proceeding ' +\
                       'with one blade output analysis.'
+        if 'psf' not in config['HAWC2Outputs'].keys():
+            print 'No safety factors for load analysis considered...'
         if 'data_directory' not in config['HAWC2InputWriter'].keys():
             config['HAWC2InputWriter']['data_directory'] = 'data'
         if 'turb_directory' not in config['HAWC2InputWriter'].keys():

--- a/hawc2_wrapper/hawc2_output.py
+++ b/hawc2_wrapper/hawc2_output.py
@@ -63,7 +63,11 @@ class HAWC2OutputBase(object):
             self.ch_envelope = config['ch_envelope']
             self.Nch_env = len(config['ch_envelope'])
             self.Nx_envelope = config['Nx']
-
+        if 'psf' not in config.keys():
+            self.psf = {}
+        else:
+            self.psf = config['psf']
+            
     def execute(self, case_tags):
 
         case_tags['[run_dir]'] = ''
@@ -79,6 +83,13 @@ class HAWC2OutputBase(object):
         if self.ch_envelope != []:
             self.envelope = case.compute_envelope(case.sig, self.ch_envelope,
                                             int_env=True, Nx=self.Nx_envelope)
+            if self.psf != {}:
+                for c in self.psf.keys():
+                    if case_tags['[case_id]'][:5] == c:
+                        for nch, ch in enumerate(self.envelope):
+                            self.envelope[ch] = self.envelope[ch]*self.psf[c]
+                    else:
+                        continue
         else:
             self.envelope = {}
 

--- a/hawc2_wrapper/test/test_hawc2_w_envelopes_openmdao.py
+++ b/hawc2_wrapper/test/test_hawc2_w_envelopes_openmdao.py
@@ -88,14 +88,34 @@ for nsec in range(config['structural_sections']):
      'local-blade'+'{:01d}'.format(nrb+1)+'-node-'+'{:03d}'.format(nsec+1)+'-forcevec-y',
      'local-blade'+'{:01d}'.format(nrb+1)+'-node-'+'{:03d}'.format(nsec+1)+'-forcevec-z'])
                     
-                                                            
+cf['psf'] = {}
+cf['psf']['dlc12'] = 1.35
+cf['psf']['dlc13'] = 1.35
+cf['psf']['dlc14'] = 1.35
+cf['psf']['dlc15'] = 1.35
+cf['psf']['dlc21'] = 1.35
+cf['psf']['dlc22'] = 1.1
+cf['psf']['dlc23'] = 1.1
+cf['psf']['dlc24'] = 1.35
+cf['psf']['dlc31'] = 1.35
+cf['psf']['dlc32'] = 1.35
+cf['psf']['dlc33'] = 1.35
+cf['psf']['dlc41'] = 1.35
+cf['psf']['dlc42'] = 1.35
+cf['psf']['dlc51'] = 1.35
+cf['psf']['dlc61'] = 1.35
+cf['psf']['dlc62'] = 1.1
+cf['psf']['dlc63'] = 1.35
+cf['psf']['dlc64'] = 1.35
+cf['psf']['dlc81'] = 1.5
+
 config['HAWC2Outputs'] = cf
 
-root.add('loads', HAWC2AeroElasticSolver(config, './DLCs_longer/', None, None), promotes=['*'])
+root.add('loads', HAWC2AeroElasticSolver(config, './DLCs_longer/'), promotes=['*'])
 
 
 top.setup()
 
 top.run()
 
-#print(top.root.loads.unknowns['aggregate.envelope_sec1'])
+#print(top.root.loads.unknowns['blade_loads_envelope_sec000'])


### PR DESCRIPTION
- Safety factors can be considered for load envelopes;
- a dictonary can be added to the hawc2output dictonary (the key is 'psf')
- each key of this dictionary is a dlc identifier and the value the respective safety factor;
- example added to test_h2_w_envelope_openmdao